### PR TITLE
Fix PkgEval

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/test/external_unzippers.jl
+++ b/test/external_unzippers.jl
@@ -19,10 +19,10 @@ Extract the zip file at zippath into the directory dirpath
 Use p7zip
 """
 function unzip_p7zip(zippath, dirpath)
+    # "LANG"=>"C.UTF-8" env variable is sometimes needed to get p7zip to use utf8
     # pipe output to devnull because p7zip is noisy
-    p7zip_jll.p7zip() do exe
-        run(pipeline(`$(exe) x -y -o$(dirpath) $(zippath)`, devnull))
-    end
+    # run(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"))
+    run(pipeline(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"), devnull))
     nothing
 end
 
@@ -31,9 +31,7 @@ Extract the zip file at zippath into the directory dirpath
 Use bsdtar from libarchive
 """
 function unzip_bsdtar(zippath, dirpath)
-    LibArchive_jll.bsdtar() do exe
-        run(`$(exe) -x -f $(zippath) -C $(dirpath)`)
-    end
+    run(`$(LibArchive_jll.bsdtar()) -x -f $(zippath) -C $(dirpath)`)
     nothing
 end
 

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -106,8 +106,12 @@ include("external_unzippers.jl")
                 for i in 1:zip_nentries(dir)
                     local name = zip_name(dir, i)
                     local extracted_path = joinpath(tmpout, name)
-                    @test isfile(extracted_path)
-                    @test zip_readentry(dir, i) == read(extracted_path)
+                    if !isfile(extracted_path)
+                        @error "$(readdir(tmpout)) doesn't contain $(repr(name))"
+                        @test false
+                    else
+                        @test zip_readentry(dir, i) == read(extracted_path)
+                    end
                 end
                 # Check number of extracted files match
                 local total_files = sum(walkdir(tmpout)) do (root, dirs, files)


### PR DESCRIPTION
p7zip doesn't correctly use UTF-8 in the PkgEval. This can be worked around by setting the environment variable, `"LANG"=>"C.UTF-8"`.

https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2023-09/19/ZipArchives.primary.log