### PR TITLE
Fix ZipFileReader staying open if reading a entry with bad local header

### DIFF
--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -115,12 +115,12 @@ end
 end
 
 @testset "Different local name" begin
-    testdata = codeunits("\
-    PK\x03\x04\x14\0\0\b\0\0\0\0\0\0\xc2A\$5\x03\0\0\0\x03\0\0\0\b\0\x14\0aame.txt\
-    \x99\x99\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
-    abc\
-    PK\x01\x02-\x03\x14\0\0\b\0\0\0\0\0\0\xc2A\$5\x03\0\0\0\x03\0\0\0\b\0\0\0\0\0\0\0\0\0\0\0\xa4\x81\0\0\0\0name.txt\
-    PK\x05\x06\0\0\0\0\x01\0\x01\x006\0\0\0=\0\0\0\0\0"
+    testdata = codeunits(
+    "PK\x03\x04\x14\0\0\b\0\0\0\0\0\0\xc2A\$5\x03\0\0\0\x03\0\0\0\b\0\x14\0aame.txt"*
+    "\x99\x99\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"*
+    "abc"*
+    "PK\x01\x02-\x03\x14\0\0\b\0\0\0\0\0\0\xc2A\$5\x03\0\0\0\x03\0\0\0\b\0\0\0\0\0\0\0\0\0\0\0\xa4\x81\0\0\0\0name.txt"*
+    "PK\x05\x06\0\0\0\0\x01\0\x01\x006\0\0\0=\0\0\0\0\0"
     )
     filename = tempname()
     write(filename, testdata)
@@ -129,6 +129,7 @@ end
     @test_throws ArgumentError zip_test_entry(r, 1)
     zip_open_filereader(filename) do r
         @test_throws ArgumentError zip_test_entry(r, 1)
+        @test r._ref_counter[] == 1
     end
     # zip_open_filereader will close the file if it has an error while parsing.
     # this will let the file be removed afterwards on windows.
@@ -136,12 +137,13 @@ end
 end
 
 @testset "Invalid Deflated data" begin
-    testdata = codeunits("\
-    PK\x03\x04\x14\0\0\b\b\0\0\0\0\0\x8d\xef\x02\xd2\x03\0\0\0\x01\0\0\0\b\0\x14\0name.txt\
-    \x99\x99\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
-    abc\
-    PK\x01\x02-\x03\x14\0\0\b\b\0\0\0\0\0\x8d\xef\x02\xd2\x03\0\0\0\x01\0\0\0\b\0\0\0\0\0\0\0\0\0\0\0\xa4\x81\0\0\0\0name.txt\
-    PK\x05\x06\0\0\0\0\x01\0\x01\x006\0\0\0=\0\0\0\0\0")
+    testdata = codeunits(
+    "PK\x03\x04\x14\0\0\b\b\0\0\0\0\0\x8d\xef\x02\xd2\x03\0\0\0\x01\0\0\0\b\0\x14\0name.txt"*
+    "\x99\x99\x10\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"*
+    "abc"*
+    "PK\x01\x02-\x03\x14\0\0\b\b\0\0\0\0\0\x8d\xef\x02\xd2\x03\0\0\0\x01\0\0\0\b\0\0\0\0\0\0\0\0\0\0\0\xa4\x81\0\0\0\0name.txt"*
+    "PK\x05\x06\0\0\0\0\x01\0\x01\x006\0\0\0=\0\0\0\0\0"
+    )
     filename = tempname()
     write(filename, testdata)
     data = read(filename)
@@ -149,6 +151,7 @@ end
     @test_throws Exception zip_test_entry(r, 1)
     zip_open_filereader(filename) do r
         @test_throws Exception zip_test_entry(r, 1)
+        @test r._ref_counter[] == 1
     end
     # zip_open_filereader will close the file if it has an error while parsing.
     # this will let the file be removed afterwards on windows.


### PR DESCRIPTION
This adds an extra try-catch to ensure the reference counter is decremented if there is some issue with the local header.