### PR TITLE
BREAKING: Remove `zip_open_filereader`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "1.1.3"
+version = "2.0.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Archives can be read from any `AbstractVector{UInt8}` containing the data of a z
 For example if you download this repo as a ".zip" from github https://github.com/JuliaIO/ZipArchives.jl/archive/refs/heads/main.zip you can read this README in julia.
 
 ```julia
-using ZipArchives: ZipBufferReader, zip_names, zip_readentry
+using ZipArchives: ZipReader, zip_names, zip_readentry
 using Downloads: download
 data = take!(download("https://github.com/JuliaIO/ZipArchives.jl/archive/refs/heads/main.zip", IOBuffer()));
-archive = ZipBufferReader(data)
+archive = ZipReader(data)
 ```
 
 Check the names in the archive.
@@ -119,6 +119,7 @@ ZipArchives currently has the following limitations compared to ZipFile:
 1. No way to specify the modification time, times are set to zero dos time.
 2. No `flush` function for `ZipWriter`. `close` and `zip_append_archive` can be used instead.
 3. Requires at least Julia 1.6.
+4. No way to read an archive from an `IOStream`, `mmap` can be used instead.
 
 
 

--- a/src/ZipArchives.jl
+++ b/src/ZipArchives.jl
@@ -9,10 +9,10 @@ For example if you download this repo as a ".zip" from github https://github.com
 you can read the README in julia.
 
 ```julia
-using ZipArchives: ZipBufferReader, zip_names, zip_readentry
+using ZipArchives: ZipReader, zip_names, zip_readentry
 using Downloads: download
 data = take!(download("https://github.com/JuliaIO/ZipArchives.jl/archive/refs/heads/main.zip", IOBuffer()));
-archive = ZipBufferReader(data)
+archive = ZipReader(data)
 ```
 
 ```julia
@@ -58,8 +58,7 @@ include("filename-checks.jl")
 include("types.jl")
 
 include("reader.jl")
-export ZipFileReader
-export zip_open_filereader
+export ZipReader
 export ZipBufferReader
 
 export zip_crc32
@@ -113,7 +112,7 @@ export zip_mkdir
             end
         end
         zipdata = take!(io)
-        r = ZipBufferReader(zipdata)
+        r = ZipReader(zipdata)
         zip_readentry(r, 1)
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -24,41 +24,7 @@ struct EntryInfo
     comment_range::UnitRange{Int}
 end
 
-"""
-    struct ZipFileReader
-
-Represents a zip archive file reader returned by [`zip_open_filereader`](@ref) 
-"""
-struct ZipFileReader
-    entries::Vector{EntryInfo}
-    central_dir_buffer::Vector{UInt8}
-    central_dir_offset::Int64
-    _io::IOStream
-    _ref_counter::Base.RefValue{Int64}
-    _open::Base.RefValue{Bool}
-    _lock::ReentrantLock
-    _fsize::Int64
-    _name::String
-end
-
-#=
-This is an internal type.
-It reads the raw possibly compressed bytes.
-It should only be exposed wrapped in a 
-`TranscodingStream`
-=#
-mutable struct ZipFileEntryReader <: IO
-    r::ZipFileReader
-    p::Int64
-    mark::Int64
-    offset::Int64
-    crc32::UInt32
-    compressed_size::Int64
-    _open::Base.RefValue{Bool}
-end
-
-
-struct ZipBufferReader{T<:AbstractVector{UInt8}}
+struct ZipReader{T<:AbstractVector{UInt8}}
     entries::Vector{EntryInfo}
     central_dir_buffer::Vector{UInt8}
     central_dir_offset::Int64

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,2 +1,3 @@
 using ZipArchives # blind using to check for export issues
 using Test: @testset, @test, @test_throws, @test_logs
+using Mmap: mmap

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -7,15 +7,16 @@ include("common.jl")
             zip_writefile(w,"$i",codeunits("$(-i)"))
         end
     end
-    zip_open_filereader(filename) do r
-        @test zip_nentries(r) == N
-        for i in 1:N
-            @test zip_name(r, i) == "$(i)"
-            zip_openentry(r, i) do file
-                @test read(file, String) == "$(-i)"
-            end
+    d = mmap(filename)
+    r = ZipReader(d)
+    @test zip_nentries(r) == N
+    for i in 1:N
+        @test zip_name(r, i) == "$(i)"
+        zip_openentry(r, i) do file
+            @test read(file, String) == "$(-i)"
         end
     end
+    finalize(d)
     rm(filename)
 end
 
@@ -31,15 +32,11 @@ end
             write(w, x)
         end
     end
-    zip_open_filereader(filename) do r
-        @test zip_nentries(r) == 1
-        zip_test_entry(r, 1)
-    end
     data = read(filename)
     rm(filename)
-    r2 = ZipBufferReader(data)
-    @test zip_nentries(r2) == 1
-    zip_test_entry(r2, 1)
+    r = ZipReader(data)
+    @test zip_nentries(r) == 1
+    zip_test_entry(r, 1)
 end
 
 @testset "large offsets" begin
@@ -50,13 +47,14 @@ end
             zip_writefile(w,"$i", x)
         end
     end
-    zip_open_filereader(filename) do r
-        @test zip_nentries(r) == 2^13
-        for i in 1:2^13
-            @test zip_name(r, i) == "$(i)"
-            zip_test_entry(r, i)
-        end
+    d = mmap(filename)
+    r = ZipReader(d)
+    @test zip_nentries(r) == 2^13
+    for i in 1:2^13
+        @test zip_name(r, i) == "$(i)"
+        zip_test_entry(r, i)
     end
+    finalize(d)
     rm(filename)
 end
 
@@ -68,12 +66,13 @@ end
             zip_writefile(w,"$i", x)
         end
     end
-    zip_open_filereader(filename) do r
-        @test zip_nentries(r) == 2^16
-        for i in 1:2^16
-            @test zip_name(r, i) == "$(i)"
-            zip_test_entry(r, i)
-        end
+    d = mmap(filename)
+    r = ZipReader(d)
+    @test zip_nentries(r) == 2^16
+    for i in 1:2^16
+        @test zip_name(r, i) == "$(i)"
+        zip_test_entry(r, i)
     end
+    finalize(d)
     rm(filename)
 end

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -20,59 +20,63 @@ include("common.jl")
     rm(filename)
 end
 
-@testset "large uncompressed size" begin
-    filename = tempname()
-    ZipWriter(filename) do w
-        zip_newfile(w, "bigfile";
-            compress=true,
-            compression_level = 1,
-        )
-        x = zeros(UInt8,2^17)
-        for i in 1:2^16
-            write(w, x)
+# The following tests need 64 bit pointers
+# because they use very large zip files.
+if Sys.WORD_SIZE == 64
+    @testset "large uncompressed size" begin
+        filename = tempname()
+        ZipWriter(filename) do w
+            zip_newfile(w, "bigfile";
+                compress=true,
+                compression_level = 1,
+            )
+            x = zeros(UInt8,2^17)
+            for i in 1:2^16
+                write(w, x)
+            end
         end
+        data = read(filename)
+        rm(filename)
+        r = ZipReader(data)
+        @test zip_nentries(r) == 1
+        zip_test_entry(r, 1)
     end
-    data = read(filename)
-    rm(filename)
-    r = ZipReader(data)
-    @test zip_nentries(r) == 1
-    zip_test_entry(r, 1)
-end
 
-@testset "large offsets" begin
-    filename = tempname()
-    ZipWriter(filename) do w
-        x = rand(UInt8,2^20)
+    @testset "large offsets" begin
+        filename = tempname()
+        ZipWriter(filename) do w
+            x = rand(UInt8,2^20)
+            for i in 1:2^13
+                zip_writefile(w,"$i", x)
+            end
+        end
+        d = mmap(filename)
+        r = ZipReader(d)
+        @test zip_nentries(r) == 2^13
         for i in 1:2^13
-            zip_writefile(w,"$i", x)
+            @test zip_name(r, i) == "$(i)"
+            zip_test_entry(r, i)
         end
+        finalize(d)
+        rm(filename)
     end
-    d = mmap(filename)
-    r = ZipReader(d)
-    @test zip_nentries(r) == 2^13
-    for i in 1:2^13
-        @test zip_name(r, i) == "$(i)"
-        zip_test_entry(r, i)
-    end
-    finalize(d)
-    rm(filename)
-end
 
-@testset "large offsets and many entries" begin
-    filename = tempname()
-    ZipWriter(filename) do w
-        x = rand(UInt8,2^17)
-        for i in 1:2^16
-            zip_writefile(w,"$i", x)
+    @testset "large offsets and many entries" begin
+        filename = tempname()
+        ZipWriter(filename) do w
+            x = rand(UInt8,2^17)
+            for i in 1:2^16
+                zip_writefile(w,"$i", x)
+            end
         end
+        d = mmap(filename)
+        r = ZipReader(d)
+        @test zip_nentries(r) == 2^16
+        for i in 1:2^16
+            @test zip_name(r, i) == "$(i)"
+            zip_test_entry(r, i)
+        end
+        finalize(d)
+        rm(filename)
     end
-    d = mmap(filename)
-    r = ZipReader(d)
-    @test zip_nentries(r) == 2^16
-    for i in 1:2^16
-        @test zip_name(r, i) == "$(i)"
-        zip_test_entry(r, i)
-    end
-    finalize(d)
-    rm(filename)
 end

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -6,14 +6,14 @@ include("common.jl")
         @test repr(w) isa String
     end
     data = take!(io)
-    r = ZipBufferReader(data)
-    @test repr(r) == "ZipArchives.ZipBufferReader($(data))"
+    r = ZipReader(data)
+    @test repr(r) == "ZipArchives.ZipReader($(data))"
     @test sprint(io->(show(io, MIME"text/plain"(), r))) == """
-    22 byte, 0 entry ZipBufferReader{Vector{UInt8}}
+    22 byte, 0 entry ZipReader{Vector{UInt8}}
     total uncompressed size: 0 bytes
       """
     @test sprint(io->(show(IOContext(io, :displaysize => (3, 80)), MIME"text/plain"(), r))) == """
-    22 byte, 0 entry ZipBufferReader{Vector{UInt8}}
+    22 byte, 0 entry ZipReader{Vector{UInt8}}
     total uncompressed size: 0 bytes
       ⋮"""
 
@@ -23,15 +23,15 @@ include("common.jl")
         zip_writefile(w, "testdir/foo", b"data")
     end
     data = take!(io)
-    r = ZipBufferReader(data)
-    @test repr(r) == "ZipArchives.ZipBufferReader($(data))"
+    r = ZipReader(data)
+    @test repr(r) == "ZipArchives.ZipReader($(data))"
     @test sprint(io->(show(io, MIME"text/plain"(), r))) == """
-    252 byte, 2 entry ZipBufferReader{Vector{UInt8}}
+    252 byte, 2 entry ZipReader{Vector{UInt8}}
     total uncompressed size: 8 bytes
       "test"
       \"testdir/\""""
     @test sprint(io->(show(IOContext(io, :displaysize => (3, 80)), MIME"text/plain"(), r))) == """
-    252 byte, 2 entry ZipBufferReader{Vector{UInt8}}
+    252 byte, 2 entry ZipReader{Vector{UInt8}}
     total uncompressed size: 8 bytes
       ⋮"""
 end

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -4,7 +4,7 @@ using ZipArchives:
     zip_nentries,
     zip_name,
     zip_names,
-    ZipBufferReader,
+    ZipReader,
     zip_openentry,
     zip_readentry,
     zip_iscompressed,
@@ -13,8 +13,7 @@ using ZipArchives:
     zip_test_entry,
     zip_isdir,
     zip_isexecutablefile,
-    zip_definitely_utf8,
-    zip_open_filereader
+    zip_definitely_utf8
 
 using Test: @testset, @test, @test_throws
 
@@ -53,58 +52,47 @@ using Test: @testset, @test, @test_throws
     end
 
 
-    # Read a zip file with `ZipBufferReader` This doesn't need to be closed.
+    # Read a zip file with `ZipReader` This doesn't need to be closed.
     # It also fast for multithreaded reading.
     data = read(filename)
-    # After passing an array to ZipBufferReader
+    # After passing an array to ZipReader
     # make sure to never modify the array
-    r = ZipBufferReader(data)
+    r = ZipReader(data)
     zip_nentries(r) == 3
-    @test map(i->zip_name(r, i), 1:zip_nentries(r)) == ["test/test1.txt", "test/empty.txt", "test/test2.txt"]
-    zip_openentry(r, 1) do io
-        @test read(io, String) == "I am data inside test1.txt in the zip file"
-    end
 
-    # Read a zip file with `zip_open_filereader`
-    zip_open_filereader(filename) do r
-        @test repr(r) == "ZipArchives.zip_open_filereader($(repr(filename)))"
-        zip_nentries(r) == 3
-
-        @test zip_names(r) == ["test/test1.txt", "test/empty.txt", "test/test2.txt"]
-        @test zip_name(r, 3) == "test/test2.txt"
-        for i in (1, BigInt(1), "test/test1.txt")
-            zip_openentry(r, i) do io
-                @test read(io, String) == "I am data inside test1.txt in the zip file"
-            end
+    @test zip_names(r) == ["test/test1.txt", "test/empty.txt", "test/test2.txt"]
+    @test zip_name(r, 3) == "test/test2.txt"
+    for i in (1, BigInt(1), "test/test1.txt")
+        zip_openentry(r, i) do io
+            @test read(io, String) == "I am data inside test1.txt in the zip file"
         end
-        # or the equivalent with zip_readentry
-        @test zip_readentry(r, 1, String) == "I am data inside test1.txt in the zip file"
-        # zip_openentry and zip_readentry can also open the last matching entry by name.
-        @test zip_readentry(r, "test/test1.txt", String) == "I am data inside test1.txt in the zip file"
-        @test_throws ArgumentError("entry with name \"test1.txt\" not found") zip_readentry(r, "test1.txt", String)
-
-        # entries are not compressed by default
-        @test !zip_iscompressed(r, 1)
-        @test zip_compressed_size(r, 1) == ncodeunits("I am data inside test1.txt in the zip file")
-        @test zip_compressed_size(r, 1) == zip_uncompressed_size(r, 1)
-
-        # Test that an entry has a correct checksum.
-        zip_test_entry(r, 3)
-
-        # entries are not marked as executable by default
-        @test !zip_isexecutablefile(r, 1)
-
-        # entries are not marked as directories by default
-        @test !zip_isdir(r, 1)
-        # zip_isdir can also check if a directory is implicitly in the archive
-        @test zip_isdir(r, "test")
-        @test zip_isdir(r, "test/")
-        @test !zip_isdir(r, "test/test1.txt")
-
-        # entry names are marked as utf8
-        @test zip_definitely_utf8(r, 1)
-
     end
+    # or the equivalent with zip_readentry
+    @test zip_readentry(r, 1, String) == "I am data inside test1.txt in the zip file"
+    # zip_openentry and zip_readentry can also open the last matching entry by name.
+    @test zip_readentry(r, "test/test1.txt", String) == "I am data inside test1.txt in the zip file"
+    @test_throws ArgumentError("entry with name \"test1.txt\" not found") zip_readentry(r, "test1.txt", String)
+
+    # entries are not compressed by default
+    @test !zip_iscompressed(r, 1)
+    @test zip_compressed_size(r, 1) == ncodeunits("I am data inside test1.txt in the zip file")
+    @test zip_compressed_size(r, 1) == zip_uncompressed_size(r, 1)
+
+    # Test that an entry has a correct checksum.
+    zip_test_entry(r, 3)
+
+    # entries are not marked as executable by default
+    @test !zip_isexecutablefile(r, 1)
+
+    # entries are not marked as directories by default
+    @test !zip_isdir(r, 1)
+    # zip_isdir can also check if a directory is implicitly in the archive
+    @test zip_isdir(r, "test")
+    @test zip_isdir(r, "test/")
+    @test !zip_isdir(r, "test/test1.txt")
+
+    # entry names are marked as utf8
+    @test zip_definitely_utf8(r, 1)
 
 
 

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -52,8 +52,7 @@ using Test: @testset, @test, @test_throws
     end
 
 
-    # Read a zip file with `ZipReader` This doesn't need to be closed.
-    # It also fast for multithreaded reading.
+    # Read a zip file with `ZipReader`.
     data = read(filename)
     # After passing an array to ZipReader
     # make sure to never modify the array

--- a/test/ttfx.jl
+++ b/test/ttfx.jl
@@ -1,7 +1,7 @@
 using Pkg.Artifacts: @artifact_str
-using ZipArchives: ZipBufferReader, zip_names, zip_readentry
+using ZipArchives: ZipReader, zip_names, zip_readentry
 
-r = ZipBufferReader(read(joinpath(artifact"fixture", "fixture", "ubuntu22-7zip.zip")))
+r = ZipReader(read(joinpath(artifact"fixture", "fixture", "ubuntu22-7zip.zip")))
 println(length(zip_names(r)))
 println(length(zip_readentry(r, "ZipArchives.jl", String)))
 println(length(zip_readentry(r, 1, String)))


### PR DESCRIPTION
This PR removes the `zip_open_filereader` function and the `ZipFileReader` type.
It also renames `ZipBufferReader` to `ZipReader`.
`ZipBufferReader` can still be used as an alias for `ZipReader`.

I don't use `zip_open_filereader` because I found using `mmap` or `read` and `ZipBufferReader` way faster and easier.

I also underestimated the maintenance cost of implementing the Julia `IO` interface. The `AbstractVector{UInt8}` interface is much easier to use.

This will hopefully be the last breaking change needed.