### PR TITLE
Remove LibArchive_jll tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
             version: '1.6'
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,7 +2,6 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
-LibArchive_jll = "1e303b3e-d4db-56ce-88c4-91e52606a1a8"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/test/external_unzippers.jl
+++ b/test/external_unzippers.jl
@@ -3,7 +3,6 @@
 # These functions take a zipfile path and a directory path and extract the zipfile into the directory
 import ZipFile
 import p7zip_jll
-import LibArchive_jll
 # ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
 try
     import PythonCall
@@ -22,15 +21,6 @@ function unzip_p7zip(zippath, dirpath)
     # pipe output to devnull because p7zip is noisy
     # run(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"))
     run(pipeline(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"), devnull))
-    nothing
-end
-
-"""
-Extract the zip file at zippath into the directory dirpath
-Use bsdtar from libarchive
-"""
-function unzip_bsdtar(zippath, dirpath)
-    run(`$(LibArchive_jll.bsdtar()) -x -f $(zippath) -C $(dirpath)`)
     nothing
 end
 
@@ -79,7 +69,6 @@ end
 
 unzippers = Any[
     unzip_p7zip,
-    unzip_bsdtar,
 ]
 
 if have_python()


### PR DESCRIPTION
This removes `LibArchive_jll` and `XZ_jll` from the test env. This also allows the test env to use updated versions of `OpenSSL_jll`.