### PR TITLE
Keep track of offset without `position`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ multiple computers, not to backup a directory and preserve all local filesystem 
 
 All public functions are exported, non exported functions and struct fields are internal.
 
-See [test/test_simple-usage.jl](test/test_simple-usage.jl) for more examples.
+See [test/test_simple-usage.jl](https://github.com/JuliaIO/ZipArchives.jl/blob/main/test/test_simple-usage.jl) for more examples.
 
 
 ### Background

--- a/src/types.jl
+++ b/src/types.jl
@@ -83,7 +83,7 @@ mutable struct ZipWriter{S<:IO} <: IO
             check_names::Bool=true,
             own_io::Bool=false,
             force_zip64::Bool=false,
-            offset::Int64=0,
+            offset::Int64=Int64(0),
         )
         new{typeof(io)}(
             WriteOffsetTracker(io, false, offset),

--- a/src/types.jl
+++ b/src/types.jl
@@ -48,7 +48,7 @@ Base.@kwdef mutable struct PartialEntry
     local_header_size::Int64 = 50 + ncodeunits(name)
 end
 
-# Internal type to keep track of ZipWriter IO offsets and error state.
+# Internal type to keep track of ZipWriter's underlying IO offset and error state.
 # inspired by https://github.com/madler/zipflow/blob/main/zipflow.c
 mutable struct WriteOffsetTracker{S<:IO} <: IO
     io::S

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -177,6 +177,7 @@ function zip_newfile(w::ZipWriter, name::AbstractString;
     )
     @argcheck isopen(w)
     zip_commitfile(w)
+    w._io.bad && throw_bad_io()
     namestr::String = String(name)
     @argcheck ncodeunits(namestr) ≤ typemax(UInt16)
     @argcheck ncodeunits(comment) ≤ typemax(UInt16)

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -306,6 +306,15 @@ end
             @test read(entryio, String) == "inner2 text"
         end
     end
+    @testset "maxsize IOBuffer" begin
+        io = IOBuffer(;maxsize=10)
+        # TODO fix writing to IOBuffer(;append=true)
+        @test_throws ArgumentError ZipWriter(io) do w
+            zip_newfile(w, "inner.txt")
+            write(w, "inner most text")
+        end
+        @test_throws ArgumentError ZipReader(take!(io))
+    end
     @testset "GzipCompressorStream" begin
         filename = tempname()
         ZipWriter(GzipCompressorStream(open(filename; write=true)); own_io=true) do w

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -269,13 +269,42 @@ end
             @test read(entryio, String) == "inner2 text"
         end
 
-        # To avoid this call seekend before creating the zipwriter
-        # if using Base.Filesystem.open with JL_O_APPEND
         io = Base.Filesystem.open(filename, FLAGS, PERMISSIONS)
-        @test_throws ArgumentError ZipWriter(io; own_io=true) do w
+        ZipWriter(io; own_io=true) do w
+            zip_writefile(w, "bad offset.txt", codeunits("bad offset text"))
         end
+        @test_throws ArgumentError ZipReader(read(filename))
+
+        io = Base.Filesystem.open(filename, FLAGS, PERMISSIONS)
+        ZipWriter(io; own_io=true, offset=filesize(io)) do w
+            zip_writefile(w, "good offset.txt", codeunits("good offset text"))
+        end
+        r = ZipReader(read(filename))
+        @test zip_names(r) == ["good offset.txt"]
 
         rm(filename)
+    end
+    @testset "Append only IOBuffer" begin
+        io = IOBuffer(;append=true)
+        # TODO fix writing to IOBuffer(;append=true)
+        ZipWriter(io) do w
+            zip_newfile(w, "inner.txt")
+            write(w, "inner most text")
+            @test_throws ArgumentError zip_commitfile(w)
+            @test !iswritable(w)
+            zip_writefile(w, "inner2.txt", codeunits("inner2 text"))
+            zip_newfile(w, "inner3.txt")
+            write(w, "inner3 text")
+            zip_abortfile(w)
+            zip_newfile(w, "inner4.txt")
+            write(w, "inner4 text")
+            @test_throws ArgumentError zip_commitfile(w)
+        end
+        r = ZipReader(take!(io))
+        @test zip_names(r) == ["inner2.txt"]
+        zip_openentry(r, 1) do entryio
+            @test read(entryio, String) == "inner2 text"
+        end
     end
     @testset "GzipCompressorStream" begin
         filename = tempname()


### PR DESCRIPTION
This change was inspired by the `zip_put` function in 

https://github.com/madler/zipflow/blob/dd2c33bc91ef2142c96472656cb540ae8c1d8281/zipflow.c#L111-L121

This allows writing zip archives to `IO` types that don't have a consistent `position` implementation.