### PR TITLE
Change DOS date from 0x0000 to 0x0021

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Currently ZipArchives has the following benefits over ZipFile:
 6. Ability to append to an existing zip archive, in an `IO` or in a file on disk.
 
 ZipArchives currently has the following limitations compared to ZipFile:
-1. No way to specify the modification time, times are set to zero dos time.
+1. No way to specify the modification time, times are set to 1980-01-01 00:00:00 DOS date time.
 2. No `flush` function for `ZipWriter`. `close` and `zip_append_archive` can be used instead.
 3. Requires at least Julia 1.6.
 4. No way to read an archive from an `IOStream`, `mmap` can be used instead.

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -710,7 +710,6 @@ function zip_openentry(r::ZipReader, i::Int)
     @argcheck entry_data_offset ≤ fsize - compressed_size
 
     @argcheck read(io, local_name_len) == view(r.central_dir_buffer, entry.name_range)
-    skip(io, extra_len)
 
     begin_ind::Int64 = firstindex(r.buffer)
     startidx = begin_ind + entry_data_offset

--- a/src/types.jl
+++ b/src/types.jl
@@ -37,8 +37,8 @@ Base.@kwdef mutable struct PartialEntry
     comment::String = ""
     external_attrs::UInt32 = UInt32(0o0100644)<<16 # external file attributes: https://unix.stackexchange.com/questions/14705/the-zip-formats-external-file-attribute
     method::UInt16 = Store # compression method
-    dos_time::UInt16 = 0 # last mod file time
-    dos_date::UInt16 = 0 # last mod file date
+    dos_time::UInt16 = 0x0000 # last mod file time
+    dos_date::UInt16 = 0x0021 # last mod file date
     force_zip64::Bool = false
     offset::UInt64
     bit_flags::UInt16 = 1<<11 # general purpose bit flag: 11 UTF-8 encoding

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Malt = "36869731-bdee-424d-aa32-cab38c994e3b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/test/external_unzippers.jl
+++ b/test/external_unzippers.jl
@@ -1,7 +1,6 @@
 # Used to test that zip files written by ZipArchives.jl can be read by other programs.
 # This defines a vector of functions in `unzippers`
 # These functions take a zipfile path and a directory path and extract the zipfile into the directory
-import ZipFile
 import p7zip_jll
 # ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
 try

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -123,45 +123,47 @@ include("external_unzippers.jl")
     end
 end
 
-@testset "Writer compat with ZipStreams" begin
-    # setup test env for ZipStreams
-    worker = Malt.Worker()
-    Malt.remote_eval_fetch(worker, quote
-        import Pkg
-        Pkg.activate(;temp=true)
-        Pkg.add(name="ZipStreams", version="2.1.0")
-        import ZipStreams
-        nothing
-    end)
-    for filename in readdir(tmp)
-        endswith(filename, ".zip") || continue
-        zippath = joinpath(tmp, filename)
-        dir = ZipReader(read(zippath))
+if VERSION ≥ v"1.7.0" # ZipStreams requires julia 1.7
+    @testset "Writer compat with ZipStreams" begin
+        # setup test env for ZipStreams
+        worker = Malt.Worker()
         Malt.remote_eval_fetch(worker, quote
-            ZipStreams.zipsource($(zippath)) do zs
-                ZipStreams.validate(zs)
-            end
+            import Pkg
+            Pkg.activate(;temp=true)
+            Pkg.add(name="ZipStreams", version="2.1.0")
+            import ZipStreams
             nothing
         end)
-        Malt.remote_eval_fetch(worker, quote
-            zs = ZipStreams.zipsource($(zippath))
-            nothing
-        end)
-        for i in 1:zip_nentries(dir)
-            name, data = Malt.remote_eval_fetch(worker, quote
-                f = ZipStreams.next_file(zs)
-                (f.info.name, read(f,String))
+        for filename in readdir(tmp)
+            endswith(filename, ".zip") || continue
+            zippath = joinpath(tmp, filename)
+            dir = ZipReader(read(zippath))
+            Malt.remote_eval_fetch(worker, quote
+                ZipStreams.zipsource($(zippath)) do zs
+                    ZipStreams.validate(zs)
+                end
+                nothing
             end)
-            @test zip_readentry(dir, name, String) == data
+            Malt.remote_eval_fetch(worker, quote
+                zs = ZipStreams.zipsource($(zippath))
+                nothing
+            end)
+            for i in 1:zip_nentries(dir)
+                name, data = Malt.remote_eval_fetch(worker, quote
+                    f = ZipStreams.next_file(zs)
+                    (f.info.name, read(f,String))
+                end)
+                @test zip_readentry(dir, name, String) == data
+            end
+            @test Malt.remote_eval_fetch(worker, quote
+                    f = ZipStreams.next_file(zs)
+                    isnothing(f)
+            end)
+            Malt.remote_eval_fetch(worker, quote
+                close(zs)
+                nothing
+            end)
         end
-        @test Malt.remote_eval_fetch(worker, quote
-                f = ZipStreams.next_file(zs)
-                isnothing(f)
-        end)
-        Malt.remote_eval_fetch(worker, quote
-            close(zs)
-            nothing
-        end)
     end
 end
 


### PR DESCRIPTION
This PR allows Zip archives created with this package to be read by `ZipStreams.jl`

This also matches the dos date used by Info-Zip when run with the `-X` flag and 7zip when run with the `-mtm-` flag.

This date is "1980-01-01", the previous date was the invalid "1980-00-00"

