### PR TITLE
Add back LibArchive tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           show-versioninfo: true
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+LibArchive_jll = "1e303b3e-d4db-56ce-88c4-91e52606a1a8"
 Malt = "36869731-bdee-424d-aa32-cab38c994e3b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/test/external_unzippers.jl
+++ b/test/external_unzippers.jl
@@ -2,6 +2,7 @@
 # This defines a vector of functions in `unzippers`
 # These functions take a zipfile path and a directory path and extract the zipfile into the directory
 import p7zip_jll
+import LibArchive_jll
 # ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
 try
     import PythonCall
@@ -20,6 +21,15 @@ function unzip_p7zip(zippath, dirpath)
     # pipe output to devnull because p7zip is noisy
     # run(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"))
     run(pipeline(addenv(`$(p7zip_jll.p7zip()) x -y -o$(dirpath) $(zippath)`, "LANG"=>"C.UTF-8"), devnull))
+    nothing
+end
+
+"""
+Extract the zip file at zippath into the directory dirpath
+Use bsdtar from libarchive
+"""
+function unzip_bsdtar(zippath, dirpath)
+    run(`$(LibArchive_jll.bsdtar()) -x -f $(zippath) -C $(dirpath)`)
     nothing
 end
 
@@ -68,6 +78,7 @@ end
 
 unzippers = Any[
     unzip_p7zip,
+    unzip_bsdtar,
 ]
 
 if have_python()

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -130,7 +130,7 @@ if VERSION ≥ v"1.7.0" # ZipStreams requires julia 1.7
         Malt.remote_eval_fetch(worker, quote
             import Pkg
             Pkg.activate(;temp=true)
-            Pkg.add(name="ZipStreams", version="2.1.0")
+            Pkg.add(name="ZipStreams", version="2.1.1")
             import ZipStreams
             nothing
         end)


### PR DESCRIPTION
This tests against the new version of `LibArchive_jll`.

Reverts #44 now that `LibArchive_jll` has been updated.