### PR TITLE
Replace call to `finalize` with `GC.gc()` to fix tests on julia 1.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          # - 'nightly'
+          - '~1.11.0-0'
         os:
           - ubuntu-latest
           - macOS-13 # intel

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -16,7 +16,7 @@ include("common.jl")
             @test read(file, String) == "$(-i)"
         end
     end
-    GC.gc()
+    d=nothing; GC.gc()
     rm(filename)
 end
 
@@ -57,7 +57,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        GC.gc()
+        d=nothing; GC.gc()
         rm(filename)
     end
 
@@ -76,7 +76,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        GC.gc()
+        d=nothing; GC.gc()
         rm(filename)
     end
 end

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -16,7 +16,7 @@ include("common.jl")
             @test read(file, String) == "$(-i)"
         end
     end
-    finalize(d)
+    GC.gc()
     rm(filename)
 end
 
@@ -57,7 +57,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        finalize(d)
+        GC.gc()
         rm(filename)
     end
 
@@ -76,7 +76,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        finalize(d)
+        GC.gc()
         rm(filename)
     end
 end

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -1,14 +1,16 @@
 include("common.jl")
 
+filenames = []
 @testset "$N many entries" for N in [0, 1, 2^16-1, 2^16,]
-    filename = tempname()
+    local filename = tempname()
+    push!(filenames, filename)
     ZipWriter(filename) do w
         for i in 1:N
             zip_writefile(w,"$i",codeunits("$(-i)"))
         end
     end
-    d = mmap(filename)
-    r = ZipReader(d)
+    local d = mmap(filename)
+    local r = ZipReader(d)
     @test zip_nentries(r) == N
     for i in 1:N
         @test zip_name(r, i) == "$(i)"
@@ -16,9 +18,10 @@ include("common.jl")
             @test read(file, String) == "$(-i)"
         end
     end
-    d=nothing; r=nothing; GC.gc()
-    rm(filename)
 end
+GC.gc()
+rm.(filenames)
+empty!(filenames)
 
 # The following tests need 64 bit pointers
 # because they use very large zip files.
@@ -41,9 +44,11 @@ if Sys.WORD_SIZE == 64
         @test zip_nentries(r) == 1
         zip_test_entry(r, 1)
     end
+end
 
+filename = tempname()
+if Sys.WORD_SIZE == 64
     @testset "large offsets" begin
-        filename = tempname()
         ZipWriter(filename) do w
             x = rand(UInt8,2^20)
             for i in 1:2^13
@@ -57,12 +62,14 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        d=nothing; r=nothing; GC.gc()
-        rm(filename)
     end
+end
+GC.gc()
+rm(filename; force=true)
 
+filename = tempname()
+if Sys.WORD_SIZE == 64
     @testset "large offsets and many entries" begin
-        filename = tempname()
         ZipWriter(filename) do w
             x = rand(UInt8,2^17)
             for i in 1:2^16
@@ -76,7 +83,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        d=nothing; r=nothing; GC.gc()
-        rm(filename)
     end
 end
+GC.gc()
+rm(filename; force=true)

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -16,7 +16,7 @@ include("common.jl")
             @test read(file, String) == "$(-i)"
         end
     end
-    d=nothing; GC.gc()
+    d=nothing; r=nothing; GC.gc()
     rm(filename)
 end
 
@@ -57,7 +57,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        d=nothing; GC.gc()
+        d=nothing; r=nothing; GC.gc()
         rm(filename)
     end
 
@@ -76,7 +76,7 @@ if Sys.WORD_SIZE == 64
             @test zip_name(r, i) == "$(i)"
             zip_test_entry(r, i)
         end
-        d=nothing; GC.gc()
+        d=nothing; r=nothing; GC.gc()
         rm(filename)
     end
 end

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -287,6 +287,7 @@ function rewrite_zip(old::AbstractString, new::AbstractString)
             end
         end
     finally
-        GC.gc()
+        d=nothing; GC.gc()
     end
+    d=nothing; GC.gc()
 end

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -287,6 +287,6 @@ function rewrite_zip(old::AbstractString, new::AbstractString)
             end
         end
     finally
-        finalize(d)
+        GC.gc()
     end
 end


### PR DESCRIPTION
In Julia 1.11 calling `finalize` on the `Vector` from `mmap` doesn't unmap, because the finalizer is now attached to the internal `Memory`. Ref: https://github.com/JuliaLang/julia/pull/54210