### PR TITLE
Fix `zip_crc32` of views of arrays with non `Int` indexes

### DIFF
--- a/src/reader.jl
+++ b/src/reader.jl
@@ -28,7 +28,7 @@ Return the standard zip CRC32 checksum of data
 See also [`zip_stored_crc32`](@ref), [`zip_test_entry`](@ref).
 """
 function zip_crc32(data::ByteArray, crc::UInt32=UInt32(0))::UInt32
-    GC.@preserve data unsafe_crc32(pointer(data), UInt(length(data)), crc)
+    GC.@preserve data unsafe_crc32(pointer(data, 1), UInt(length(data)), crc)
 end
 
 function zip_crc32(data::AbstractVector{UInt8}, crc::UInt32=UInt32(0))::UInt32

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -28,7 +28,7 @@ Return the standard zip CRC32 checksum of data
 See also [`zip_stored_crc32`](@ref), [`zip_test_entry`](@ref).
 """
 function zip_crc32(data::ByteArray, crc::UInt32=UInt32(0))::UInt32
-    GC.@preserve data unsafe_crc32(pointer(data, 1), UInt(length(data)), crc)
+    GC.@preserve data unsafe_crc32(pointer(data, Int(firstindex(data))), UInt(length(data)), crc)
 end
 
 function zip_crc32(data::AbstractVector{UInt8}, crc::UInt32=UInt32(0))::UInt32

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -423,3 +423,11 @@ end
 @testset "crc32 of offset arrays" begin
     @test zip_crc32(Origin(0)(b"hello")) == zip_crc32(b"hello")
 end
+
+@testset "crc32 of views of arrays with non Int indexes" begin
+    data = rand(UInt8, 1000)
+    r = zip_crc32(data[2:90])
+    for T in (BigInt, UInt64, Int64)
+        @test r == zip_crc32(view(data, T(2):T(90)))
+    end
+end


### PR DESCRIPTION
For some reason `pointer(view([0x00,0x01], big(1):big(2)))` throws an error, but  `pointer(view([0x00,0x01], big(1):big(2)), 1)` works.