### PR TITLE
Experimental `zip_entry_data_offset` and `zip_compression_method` functions.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -701,6 +701,17 @@ function Base.show(io::IO, ::MIME"text/plain", r::ZipReader)
     end
 end
 
+"""
+    zip_entry_data_offset(r::ZipReader, i::Integer)::Int64
+
+Return the offset of the start of the compressed data for entry `i` from
+the start of the buffer in `r`.
+
+Throw an error if the local header is invalid.
+
+See also [`zip_compression_method`](@ref) and [`zip_compressed_size`](@ref).
+"""
+zip_entry_data_offset(r::ZipReader, i::Integer) = zip_entry_data_offset(r, Int(i))
 function zip_entry_data_offset(r::ZipReader, i::Int)::Int64
     fsize::Int64 = length(r.buffer)
     entry::EntryInfo = r.entries[i]

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -151,6 +151,12 @@ end
     @test_throws ArgumentError("invalid compression method: 14. Only Store(0) and Deflate(8) supported for now") zip_openentry(r, 1)
     @test zip_iscompressed(r, 1)
     @test zip_names(r) == ["lzma_data"]
+    @test ZipArchives.zip_compression_method(r, 1) === 0x000e
+    entry_data_offset = 39
+    compressed_size = 34
+    @test ZipArchives.zip_entry_data_offset(r, 1) === Int64(entry_data_offset)
+    @test ZipArchives.zip_entry_data_offset(r, big(1)) === Int64(entry_data_offset)
+    @test ZipArchives.zip_compressed_size(r, 1) === UInt64(compressed_size)
 end
 
 @testset "reading file with zip64 disk number" begin

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -147,8 +147,8 @@ end
     data_b64 = "UEsDBD8AAgAOAHJb0FaLksVmIgAAABAAAAAJAAAAbHptYV9kYXRhCQQFAF0AAIAAADoaCWd+rnMR0beE5IbQKkMGbV//6/YgAFBLAQI/AD8AAgAOAHJb0FaLksVmIgAAABAAAAAJAAAAAAAAAAAAAACAAQAAAABsem1hX2RhdGFQSwUGAAAAAAEAAQA3AAAASQAAAAAA"
     data = base64decode(data_b64)
     r = ZipReader(data)
-    @test_throws ArgumentError("invalid compression method: 14. Only Store and Deflate supported for now") zip_test_entry(r, 1)
-    @test_throws ArgumentError("invalid compression method: 14. Only Store and Deflate supported for now") zip_openentry(r, 1)
+    @test_throws ArgumentError("invalid compression method: 14. Only Store(0) and Deflate(8) supported for now") zip_test_entry(r, 1)
+    @test_throws ArgumentError("invalid compression method: 14. Only Store(0) and Deflate(8) supported for now") zip_openentry(r, 1)
     @test zip_iscompressed(r, 1)
     @test zip_names(r) == ["lzma_data"]
 end


### PR DESCRIPTION
This PR adds two experimental functions.

1. `zip_compression_method(x::HasEntries, i::Integer)::UInt16`
2. `zip_entry_data_offset(r::ZipReader, i::Integer)::Int64`

These are not public yet.

This should make working on #49 easier because the compressed entry data can be read externally using the compressed size and offset.