### PR TITLE
Avoid extra allocations when reading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "2.1.5"
+version = "2.1.6"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -35,12 +35,10 @@ function zip_crc32(data::AbstractVector{UInt8}, crc::UInt32=UInt32(0))::UInt32
     zip_crc32(collect(data), crc)
 end
 
-# Copied from ZipFile.jl
-readle(io::IO, ::Type{UInt64}) = htol(read(io, UInt64))
-readle(io::IO, ::Type{UInt32}) = htol(read(io, UInt32))
-readle(io::IO, ::Type{UInt16}) = htol(read(io, UInt16))
-readle(io::IO, ::Type{UInt8}) = read(io, UInt8)
-
+@inline readle(io::IO, ::Type{UInt64}) = UInt64(readle(io, UInt32)) | UInt64(readle(io, UInt32))<<32
+@inline readle(io::IO, ::Type{UInt32}) = UInt32(readle(io, UInt16)) | UInt32(readle(io, UInt16))<<16
+@inline readle(io::IO, ::Type{UInt16}) = UInt16(read(io, UInt8)) | UInt16(read(io, UInt8))<<8
+@inline readle(io::IO, ::Type{UInt8}) = read(io, UInt8)
 
 #=
 Return the minimum size of a local header for an entry.


### PR DESCRIPTION
`read(io, UInt16)` and `read(io, UInt32)` can lead to allocations. Replace it with reading individual bytes and shifting.

```julia-repl
julia> using ZipArchives

julia> using BenchmarkTools

julia> io = IOBuffer();

julia> ZipWriter(io) do w
           for i in 1:1000
               zip_writefile(w, "test/$(i).txt", codeunits("test data"))
           end
       end;

julia> d = take!(io);

julia> @btime ZipReader($d);
```

This PR:   19.337 μs (7 allocations: 142.78 KiB)
main: 119.206 μs (16014 allocations: 392.92 KiB)