### PR TITLE
New lower-level reading functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "2.1.7"
+version = "2.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/ZipArchives.jl
+++ b/src/ZipArchives.jl
@@ -60,7 +60,7 @@ include("types.jl")
 
 include("reader.jl")
 export ZipReader
-export ZipBufferReader
+export ZipBufferReader # alias for ZipReader for compat reasons
 
 export zip_crc32
 
@@ -76,6 +76,9 @@ export zip_isdir
 export zip_isexecutablefile
 export zip_findlast_entry
 export zip_comment
+export zip_compression_method
+export zip_general_purpose_bit_flag
+export zip_entry_data_offset
 
 export zip_test_entry
 export zip_openentry

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -111,6 +111,16 @@ Note: if the zip file was corrupted, this might be wrong.
 zip_compression_method(x::HasEntries, i::Integer)::UInt16 = x.entries[i].method
 
 """
+    zip_general_purpose_bit_flag(x::HasEntries, i::Integer)::UInt16
+
+Return the general purpose bit flag for entry `i`.
+
+See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT 
+for a description of the bits.
+"""
+zip_general_purpose_bit_flag(x::HasEntries, i::Integer)::UInt16 = x.entries[i].bit_flags
+
+"""
     zip_iscompressed(x::HasEntries, i::Integer)::Bool
 
 Return if entry `i` is marked as compressed.

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -151,12 +151,15 @@ end
     @test_throws ArgumentError("invalid compression method: 14. Only Store(0) and Deflate(8) supported for now") zip_openentry(r, 1)
     @test zip_iscompressed(r, 1)
     @test zip_names(r) == ["lzma_data"]
-    @test ZipArchives.zip_compression_method(r, 1) === 0x000e
+    @test zip_compression_method(r, 1) === 0x000e
+    @test zip_general_purpose_bit_flag(r, 1) === 0x0002 # indicates
+    # an end-of-stream (EOS) marker is used to
+    # mark the end of the compressed data stream
     entry_data_offset = 39
     compressed_size = 34
-    @test ZipArchives.zip_entry_data_offset(r, 1) === Int64(entry_data_offset)
-    @test ZipArchives.zip_entry_data_offset(r, big(1)) === Int64(entry_data_offset)
-    @test ZipArchives.zip_compressed_size(r, 1) === UInt64(compressed_size)
+    @test zip_entry_data_offset(r, 1) === Int64(entry_data_offset)
+    @test zip_entry_data_offset(r, big(1)) === Int64(entry_data_offset)
+    @test zip_compressed_size(r, 1) === UInt64(compressed_size)
 end
 
 @testset "reading file with zip64 disk number" begin


### PR DESCRIPTION
This PR exports three new functions useful for lower-level reading of raw entry data.

    zip_compression_method(x::HasEntries, i::Integer)::UInt16

Return the compression method used for entry `i`.
See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT for a current list of methods.
Only Store(0x0000) and Deflate(0x0008) supported for now.
Note: if the zip file was corrupted, this might be wrong.

    zip_general_purpose_bit_flag(x::HasEntries, i::Integer)::UInt16

Return the general purpose bit flag for entry `i`.

See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT 
for a description of the bits.

    zip_entry_data_offset(r::ZipReader, i::Integer)::Int64

Return the offset of the start of the compressed data for entry `i` from
the start of the buffer in `r`.
Throw an error if the local header is invalid.