### PR TITLE
Remove unreliable warning when reading

### DIFF
--- a/src/reader.jl
+++ b/src/reader.jl
@@ -603,13 +603,16 @@ function parse_central_directory_headers!(central_dir_buffer::Vector{UInt8}, num
         )
     end
     # Maybe num_entries was too small: See https://github.com/thejoshwolfe/yauzl/issues/60
-    # In that case just log a warning
-    if bytesavailable(io_b) ≥ 4
-        if readle(io_b, UInt32) == 0x02014b50
-            @warn "There may be some entries that are being ignored"
-        end
-        skip(io_b, -4)
-    end
+    # In that case ignore any potential extra entries.
+    # Logging a warning here is not part of the zip spec, and causes JET
+    # to complain.
+    # Commented out warning:
+    # if bytesavailable(io_b) ≥ 4
+    #     if readle(io_b, UInt32) == 0x02014b50
+    #         @warn "There may be some entries that are being ignored"
+    #     end
+    #     skip(io_b, -4)
+    # end
 
     resize!(central_dir_buffer, position(io_b))
     entries

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -95,8 +95,9 @@ end
     @test isempty(entries)
     @test central_dir_offset == 0
 
+    # @test_logs (:warn,"There may be some entries that are being ignored")
     io = IOBuffer([b"PK\x01\x02"; b"PK\x05\x06"; zeros(UInt8,2*4+4*2+2)])
-    @test_logs (:warn,"There may be some entries that are being ignored") entries, central_dir_buffer, central_dir_offset = ZipArchives.parse_central_directory(io)
+    entries, central_dir_buffer, central_dir_offset = ZipArchives.parse_central_directory(io)
     @test isempty(entries)
     @test central_dir_offset == 0
 end


### PR DESCRIPTION
"I don't want everyone to pay the performance cost of Apple's incompetence/hostility if they don't want to"
Ref: https://github.com/thejoshwolfe/yauzl/issues/69

macOS Archive Utility sometimes lies about how many entries are in the central directory.

I had some code to try and detect this and log a warning. However, logging a warning is not part of the zip spec, may be unexpected, and was causing JET to complain.

This PR removes this warning.

