### PR TITLE
Add `zip_test`

### DIFF
--- a/src/ZipArchives.jl
+++ b/src/ZipArchives.jl
@@ -81,6 +81,7 @@ export zip_general_purpose_bit_flag
 export zip_entry_data_offset
 
 export zip_test_entry
+export zip_test
 export zip_openentry
 export zip_readentry
 

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -251,6 +251,22 @@ function zip_test_entry(r::ZipReader, i::Integer)::Nothing
     nothing
 end
 
+"""
+    zip_test(x::ZipReader)::Nothing
+
+Test all entries in the archive in order from `1` to `zip_nentries(r)`
+Throw an error for the first invalid entry.
+"""
+function zip_test(r::ZipReader)::Nothing
+    for i in 1:zip_nentries(r)
+        try
+            zip_test_entry(r, i)
+        catch
+            error("entry $(i): $(repr(zip_name(r, i))) is invalid")
+        end
+    end
+    nothing
+end
 
 """
     zip_openentry(r::ZipReader, i::Union{AbstractString, Integer})

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -252,7 +252,7 @@ function zip_test_entry(r::ZipReader, i::Integer)::Nothing
 end
 
 """
-    zip_test(x::ZipReader)::Nothing
+    zip_test(r::ZipReader)::Nothing
 
 Test all entries in the archive in order from `1` to `zip_nentries(r)`
 Throw an error for the first invalid entry.

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -119,6 +119,7 @@ end
     )
     r = ZipReader(testdata)
     @test_throws ArgumentError zip_test_entry(r, 1)
+    @test_throws ErrorException zip_test(r)
 end
 
 @testset "Invalid Deflated data" begin

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -89,6 +89,8 @@ using Test: @testset, @test, @test_throws
     # Test that an entry has a correct checksum.
     zip_test_entry(r, 3)
     zip_test_entry(r, 4)
+    # Test all the entries
+    zip_test(r)
 
     # entries are not marked as executable by default
     @test !zip_isexecutablefile(r, 1)


### PR DESCRIPTION
This PR adds and exports:

    zip_test(r::ZipReader)::Nothing
Test all entries in the archive in order from `1` to `zip_nentries(r)`
Throw an error for the first invalid entry.