### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
Diff: https://github.com/JuliaIO/ZipArchives.jl/compare/v2.2.0...18b5a95f3232d5241948280b6503b62839517676

This release adds the `zip_test` function for easily testing the checksums of all entries in an archive.

It also allows the `parent` function to be used to get the underlying buffer of a `ZipReader`.

Lastly, it adds support for reading Deflate64 compressed data. Deflate64 is sometimes created when zipping large files with Windows File Explorer. This fixes #49