### PR TITLE
Optimize `zip_findlast_entry` and add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.vscode/
 
 /test/Manifest.toml
+/benchmark/Manifest.toml
 /Manifest.toml
 fixture.tar.gz
 fixture

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,11 @@
+# ZipArchives.jl benchmarks
+
+This directory contains benchmarks for ZipArchives. To run all the
+benchmarks, launch `julia --project=benchmark` and enter:
+
+``` julia
+using PkgBenchmark
+import ZipArchives
+
+benchmarkpkg(ZipArchives)
+```

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,24 @@
+using BenchmarkTools
+using Random
+using ZipArchives
+
+const SUITE = BenchmarkGroup()
+rbench = SUITE["reading"] = BenchmarkGroup()
+
+sink = IOBuffer()
+names = String[]
+ZipWriter(sink) do w
+    for i in 1:2000
+        local name = String(rand(UInt8('a'):UInt8('z'), 100))
+        push!(names, name)
+        zip_writefile(w, name, rand(UInt8, 10000))
+    end
+end
+data = take!(sink)
+r = ZipReader(data)
+
+rbench["ZipReader"] = @benchmarkable ZipReader($(data))
+rbench["zip_findlast_entry nothing"] = @benchmarkable zip_findlast_entry($(r), $("abc"))
+rbench["zip_findlast_entry first"] = @benchmarkable zip_findlast_entry($(r), $(names[begin]))
+rbench["zip_findlast_entry last"] = @benchmarkable zip_findlast_entry($(r), $(names[end]))
+rbench["zip_readentry"] = @benchmarkable zip_readentry($(r), $(1000))

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -202,8 +202,9 @@ Return the index of the last entry with name `s` or `nothing` if not found.
 zip_findlast_entry(x::HasEntries, s::AbstractString)::Union{Nothing, Int} = zip_findlast_entry(x, String(s))
 function zip_findlast_entry(x::HasEntries, s::String)::Union{Nothing, Int}
     data = codeunits(s)
-    findlast(eachindex(x.entries)) do i
-        _name_view(x, i) == data
+    n = length(data)
+    findlast(x.entries) do e
+        n == length(e.name_range) && view(x.central_dir_buffer, e.name_range) == data
     end
 end
 


### PR DESCRIPTION
|                                    | main               | dirty              | main/dirty |
|:-----------------------------------|:------------------:|:------------------:|:----------:|
| reading/ZipReader                  | 0.0427 ± 0.0026 ms | 0.0429 ± 0.0027 ms | 0.995      |
| reading/zip_findlast_entry first   | 7.02 ± 0.1 μs      | 7.45 ± 0.08 μs     | 0.942      |
| reading/zip_findlast_entry last    | 0.08 ± 0.01 μs     | 0.07 ± 0.01 μs     | 1.14       |
| reading/zip_findlast_entry nothing | 5.47 ± 0.27 μs     | 1.15 ± 0.04 μs     | 4.75       |
| reading/zip_readentry              | 5.62 ± 1.2 μs      | 5.59 ± 1.2 μs      | 1.01       |
| time_to_load                       | 0.0559 ± 0.00035 s | 0.0574 ± 0.00036 s | 0.974      |