### PR TITLE
Check size of the central directory is correct when reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 /test/Manifest.toml
 /benchmark/Manifest.toml
+*.json
+*.json.tmp
 /Manifest.toml
 fixture.tar.gz
 fixture

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -22,3 +22,10 @@ rbench["zip_findlast_entry nothing"] = @benchmarkable zip_findlast_entry($(r), $
 rbench["zip_findlast_entry first"] = @benchmarkable zip_findlast_entry($(r), $(names[begin]))
 rbench["zip_findlast_entry last"] = @benchmarkable zip_findlast_entry($(r), $(names[end]))
 rbench["zip_readentry"] = @benchmarkable zip_readentry($(r), $(1000))
+
+# Reading empty archive
+sink = IOBuffer()
+ZipWriter(sink) do w
+end
+data = take!(sink)
+rbench["empty ZipReader"] = @benchmarkable ZipReader($(data))

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -505,7 +505,10 @@ function parse_central_directory(io::IO)
         end
     end
     # If num_entries is crazy high, avoid allocating crazy amount of memory
-    @argcheck num_entries ≤ central_dir_size>>5
+    # The minimum entry size is 46
+    min_central_dir_size, num_entries_overflow = Base.mul_with_overflow(num_entries, Int64(46))
+    @argcheck !num_entries_overflow
+    @argcheck min_central_dir_size ≤ central_dir_size
     seek(io, central_dir_offset)
     central_dir_buffer::Vector{UInt8} = read(io, central_dir_size)
     @argcheck length(central_dir_buffer) == central_dir_size

--- a/test/test_ported-go-tests.jl
+++ b/test/test_ported-go-tests.jl
@@ -22,14 +22,14 @@ end
     testdata = joinpath(@__DIR__,"examples from go/testdata/")
     same_content_files = [
         "test.zip",
-        "test-baddirsz.zip",
-        "test-badbase.zip",
     ]
     invalid_files = [
         "test-trailing-junk.zip",
         "test-prefix.zip",
         "readme.zip",
-        "readme.notzip"
+        "readme.notzip",
+        "test-baddirsz.zip",
+        "test-badbase.zip",
     ]
 
     for filename in same_content_files


### PR DESCRIPTION
Previously, the "size of the central directory" was not checked when reading an archive because this information is redundant in a correctly formatted archive. By adding in these checks, invalid archives can be rejected earlier.

With this change, some invalid archives that could be read before can no longer be read.