### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZipArchives"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
This version adds stricter checking of archive validity when reading. It also adds better support for the new `Memory` type in Julia 1.11.