### PR TITLE
Reuse last used compressor

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -11,7 +11,6 @@ const Deflate64 = UInt16(9)
 see https://github.com/madler/zipflow/blob/2bef2123ebe519c17b18d2d0c3c71065088de952/zipflow.c#L214
 =#
 function deflate_level_bits(level::Int)::UInt16
-    @argcheck level ∈ (-1:9)
     if level == 9
         0b010 # Maximum
     elseif level == 2

--- a/src/types.jl
+++ b/src/types.jl
@@ -79,6 +79,9 @@ mutable struct ZipWriter{S<:IO} <: IO
     used_stripped_dir_names::Set{String}
     check_names::Bool
     transcoder::Union{Nothing, NoopStream{WriteOffsetTracker{S}}, DeflateCompressorStream{WriteOffsetTracker{S}}}
+
+    "Cached codec and compression level to avoid allocations"
+    compressor_cache::Union{Nothing, Tuple{DeflateCompressor, Int}}
     function ZipWriter(io::IO;
             check_names::Bool=true,
             own_io::Bool=false,
@@ -96,6 +99,7 @@ mutable struct ZipWriter{S<:IO} <: IO
             Set{String}(),
             Set{String}(),
             check_names,
+            nothing,
             nothing,
         )
     end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -277,7 +277,6 @@ Base.write(w::ZipWriter, x::UInt8) = write(w, Ref(x))
 
 # WriteOffsetTracker
 Base.isopen(w::WriteOffsetTracker) = !w.bad
-Base.close(w::WriteOffsetTracker) = nothing # this protects the underlying stream from being closed by TranscodingStreams
 Base.isreadable(w::WriteOffsetTracker) = false
 Base.write(w::WriteOffsetTracker, x::UInt8) = write(w, Ref(x))
 


### PR DESCRIPTION
Instead of allocating a new compressor for each entry that needs compression, try and reuse the last used compressor if it has the correct compression level.

This PR requires https://github.com/JuliaIO/CodecZlib.jl/pull/97 to prevent memory leaks.