### PR TITLE
Update readme docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,9 +22,13 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
         arch:
-          - 'x64'
+          - 'default'
           - 'x86'
+        exclude:
+          - os: macos-latest
+            arch: x86
         include:
           - os: ubuntu-latest
             version: '1.6'
@@ -32,18 +36,6 @@ jobs:
           - os: ubuntu-latest
             version: '1.6'
             arch: x86
-          - os: macOS-13
-            version: '1'
-            arch: x64
-          - os: macOS-13
-            version: 'pre'
-            arch: x64
-          - os: macOS-14
-            version: '1'
-            arch: aarch64
-          - os: macOS-14
-            version: 'pre'
-            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -55,7 +47,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
-          file: lcov.info
+          files: lcov.info

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Check the names in the archive.
 zip_names(archive)
 ```
 
+Read the entire contents this README file as a `Vector{UInt8}`
+```julia
+zip_readentry(archive, "ZipArchives.jl-main/README.md")
+```
+
 Print this README file.
 ```julia
 zip_readentry(archive, "ZipArchives.jl-main/README.md", String) |> print
@@ -138,12 +143,13 @@ Currently, ZipArchives has the following benefits over ZipFile:
 4. Files can be marked as executable. Permissions are handled like in https://github.com/JuliaIO/Tar.jl#permissions
 5. By default when writing an archive, entry names are checked to avoid some common issues if the archive is extracted on Windows.
 6. Ability to append to an existing zip archive, in an `IO` or in a file on disk.
+7. [Faster file writing](https://github.com/felipenoris/XLSX.jl/pull/266).
+8. [No garbage collection bugs](https://github.com/fhs/ZipFile.jl/issues/14).
 
 ZipArchives currently has the following limitations compared to ZipFile:
 1. No way to specify the modification time, times are set to 1980-01-01 00:00:00 DOS date time.
 2. No `flush` function for `ZipWriter`. `close` and `zip_append_archive` can be used instead.
-3. Requires at least Julia 1.6.
-4. No way to read an archive from an `IOStream`, `mmap` can be used instead.
+3. No way to read an archive from an `IOStream`, `mmap` can be used instead.
 
 
 

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -66,7 +66,7 @@ using Test: @testset, @test, @test_throws
     @test zip_names(r) == ["test/test1.txt", "test/empty.txt", "test/test2.txt", "test/compressed.txt"]
     @test zip_name(r, 3) == "test/test2.txt"
 
-    @test zip_readentry(r, 1, String) == "I am data inside test1.txt in the zip file"
+    @test zip_readentry(r, 1) == codeunits("I am data inside test1.txt in the zip file")
     # zip_openentry and zip_readentry can also open the last matching entry by name.
     @test zip_readentry(r, "test/test1.txt", String) == "I am data inside test1.txt in the zip file"
     @test_throws ArgumentError("entry with name \"test1.txt\" not found") zip_readentry(r, "test1.txt", String)


### PR DESCRIPTION
Add examples of reading an entry directly as a `Vector{UInt8}` instead of a `String`