### PR TITLE
Remove use of `Base.FastContiguousSubArray` and `pointer`

### DIFF
--- a/src/reader.jl
+++ b/src/reader.jl
@@ -5,8 +5,8 @@ function unsafe_crc32(p::Ptr{UInt8}, nb::UInt, crc::UInt32)::UInt32
     )
 end
 
-# currently unsafe_convert fails on BigInt, so plain `AbstractUnitRange` can't be used
-const FastByteView{P <: AbstractVector{UInt8}} = SubArray{UInt8, 1, P, <:Tuple{AbstractUnitRange{<:Union{Int32, Int64}}}, true}
+# currently unsafe_convert fails on some AbstractUnitRange{<:Integer}, so plain `AbstractUnitRange` can't be used
+const FastByteView{P <: AbstractVector{UInt8}} = SubArray{UInt8, 1, P, <:Tuple{AbstractUnitRange{Int}}, true}
 
 if VERSION ≥ v"1.11"
     const ByteArray = Union{
@@ -284,7 +284,7 @@ function zip_test_entry(r::ZipReader, i::Integer)::Nothing
             @argcheck uncompressed_size < typemax(Int64)
             uncompressed_size += nb
             @argcheck uncompressed_size ≤ saved_uncompressed_size
-            real_crc32 = zip_crc32(view(buffer, 1:nb), real_crc32)
+            real_crc32 = zip_crc32(view(buffer, 1:Int(nb)), real_crc32)
         end
         @argcheck uncompressed_size === saved_uncompressed_size
         @argcheck saved_crc32 == real_crc32

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -51,7 +51,7 @@ function zip_crc32(data::AbstractVector{UInt8}, crc::UInt32=UInt32(0))::UInt32
     while offset < n
         nb = min(n-offset, Int64(24576))
         copyto!(buf, Int64(1), data, offset + start, nb)
-        crc = zip_crc32(view(buf, 1:nb), crc)
+        crc = zip_crc32(view(buf, 1:Int(nb)), crc)
         offset += nb
     end
     crc

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -463,9 +463,10 @@ end
 @testset "crc32 of views of arrays with non Int indexes" begin
     data = rand(UInt8, 1000)
     r = zip_crc32(data[2:90])
-    for T in (BigInt, UInt64, Int64)
+    for T in (BigInt, UInt64, Int64, UInt32, Int32, UInt8)
         @test r == zip_crc32(view(data, T(2):T(90)))
     end
+    @test zip_crc32(view(data, :)) == zip_crc32(data)
 end
 
 @testset "zip_writefile on non dense arrays" begin


### PR DESCRIPTION
`Base.FastContiguousSubArray` is private, and `Base.cconvert` + `Base.unsafe_convert` is safer under potential future GC changes compared to the `pointer` function.