### PR TITLE
Remove a vestigial GC preserve

### DIFF
--- a/src/reader.jl
+++ b/src/reader.jl
@@ -279,7 +279,7 @@ function zip_test_entry(r::ZipReader, i::Integer)::Nothing
         real_crc32::UInt32 = 0
         uncompressed_size::UInt64 = 0
         buffer = zeros(UInt8, 1<<14)
-        GC.@preserve buffer while !eof(io)
+        while !eof(io)
             nb = readbytes!(io, buffer)
             @argcheck uncompressed_size < typemax(Int64)
             uncompressed_size += nb


### PR DESCRIPTION
This cleans up a GC preserve was left over from https://github.com/JuliaIO/ZipArchives.jl/pull/94, which removed the pointer code this was protecting.

This should not have any functional changes.